### PR TITLE
Non linear complexity with alternatives in RecordFields

### DIFF
--- a/example/Person2.hs
+++ b/example/Person2.hs
@@ -7,6 +7,8 @@ module Person2 where
 
 import           Control.Applicative
 import           Data.Generics.Labels  ()
+import           Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
 import           Data.String
 import           GHC.Exts (IsList(..))
 import           Person
@@ -19,7 +21,7 @@ data Person2 = Person2
   , age       :: Int
   , addresses :: [String]
   , religion  :: (Maybe Religion)  -- new
-  , education :: Education         -- renamed
+  , education :: NonEmpty Education         -- renamed
   }
   deriving (Eq, Show)
 
@@ -40,16 +42,19 @@ instance HasSchema Person2 where
       <*> field "age"       Person2.age
       <*> field "addresses" Person2.addresses
       <*> optField "religion"  Person2.religion
-      <*> (field "education" Person2.education <|> field "studies" Person2.education)
+      <*> (field "education" Person2.education <|> (NE.:| []) <$> field "studies" (NE.head . Person2.education))
 
 pepe2 :: Person2
 pepe2 = Person2 "Pepe"
                 38
                 ["2 Edward Square", "La Mar 10"]
                 Nothing
-                (PhD "Computer Science")
+                [PhD "Computer Science", Degree "Engineering" ]
 
 -- Person2 can be encoded in multiple ways, so the canonic encoding includes all ways
+-- >>> import qualified Data.ByteString.Lazy.Char8 as B
+-- >>> import Data.Aeson.Encode.Pretty
+-- >>> B.putStrLn $ encodePretty $ encodeTo (theSchema @Person2) pepe2
 -- {
 --     "#1": {
 --         "education": {

--- a/src/Schemas/Class.hs
+++ b/src/Schemas/Class.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedLabels    #-}
 {-# LANGUAGE OverloadedLists     #-}
 {-# LANGUAGE OverloadedStrings   #-}
@@ -159,7 +160,7 @@ encode = encodeWith schema
 -- | Attempt to encode to the target schema using the default schema.
 --   First encodes using the default schema, then computes a coercion
 --   applying 'isSubtypeOf', and then applies the coercion to the encoded data.
-encodeTo :: HasSchema a => Schema -> Maybe (a -> Value)
+encodeTo :: HasSchema a => Schema -> Either [(Trace, Mismatch)] (a -> Value)
 encodeTo = encodeToWith schema
 
 -- | Encode a value into a finite representation by enforcing a max depth

--- a/test/Generators.hs
+++ b/test/Generators.hs
@@ -61,9 +61,9 @@ genSchema 0 = elements [Empty, Prim "A", Prim "B"]
 genSchema n = frequency
   [ (10,) $  Record <$> do
       nfields <- choose (1,2)
-      fieldArgs <- replicateM nfields (scale (`div` 2) arbitrary)
+      fieldArgs <- replicateM nfields (scale (`div` succ nfields) arbitrary)
       return $ fromList (zipWith (\n (sc,a) -> (n, Field sc a)) fieldNames fieldArgs)
-  , (10,) $ Array  <$> scale(`div`2) arbitrary
+  , (10,) $ Array  <$> scale(`div` 4) arbitrary
   , (10,) $ Enum   <$> do
       n <- choose (1,2)
       return $ fromList $ take n ["Enum1", "Enum2"]
@@ -71,7 +71,7 @@ genSchema n = frequency
   , (1,) $ OneOf . fromList <$> listOf1 (genSchema (n`div`10))
   , (5,) $ review _Union <$> do
       nconstructors <- choose (1,2)
-      args <- replicateM nconstructors (genSchema (n`div`nconstructors))
+      args <- replicateM nconstructors (genSchema (n`div` succ nconstructors))
       return $ fromList $ zip constructorNames args
   , (50,) $ genSchema 0
   ]


### PR DESCRIPTION
Record with alternatives lead to a combinatorial explosion of schemas, which in turn makes `decodeFrom` and `encodeTo` non linear. 
