### PR TITLE
Fix REPL issue

### DIFF
--- a/src/Schemas/SOP.hs
+++ b/src/Schemas/SOP.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
+
 module Schemas.SOP
   ( gSchema
   , HasGenericSchema
@@ -17,11 +18,12 @@ module Schemas.SOP
   )
 where
 
-import           Control.Lens (prism')
-import qualified Data.List.NonEmpty       as NE
+import           Control.Lens       (prism')
+import           Data.Kind          (Type)
+import qualified Data.List.NonEmpty as NE
 import           Data.Profunctor
-import           Data.Text                (Text, pack)
-import           Generics.SOP             as SOP
+import           Data.Text          (Text, pack)
+import           Generics.SOP       as SOP
 import           Schemas.Class
 import           Schemas.Internal
 
@@ -58,7 +60,7 @@ gSchemaNS opts ci =
     where
         mkAlts = hcollapse . hczipWith3 (Proxy :: Proxy (All FieldEncode)) mk (injections @_ @(NP I)) (ejections  @_ @(NP I))
         mk
-            :: forall (xs :: [*])
+            :: forall (xs :: [Type])
              . All FieldEncode xs
             => Injection (NP I) xss xs
             -> Ejection (NP I) xss xs
@@ -70,7 +72,7 @@ gSchemaNS opts ci =
             cons = pack (constructorTagModifier opts (constructorName ci))
 
 gSchemaNP
-    :: forall (xs :: [*])
+    :: forall (xs :: [Type])
      . (All FieldEncode xs)
     => Options
     -> ConstructorInfo xs
@@ -78,7 +80,7 @@ gSchemaNP
 gSchemaNP opts = record . gRecordFields' opts
 
 gRecordFields'
-    :: forall (xs :: [*])
+    :: forall (xs :: [Type])
      . (All FieldEncode xs)
     => Options
     -> ConstructorInfo xs


### PR DESCRIPTION
Weird failure in REPL.

```
λ cabal repl
Build profile: -w ghc-8.10.2 -O1
In order, the following will be built (use -v for more details):
 - schemas-0.4.0.2 (lib) (first run)
Preprocessing library for schemas-0.4.0.2..
GHCi, version 8.10.2: https://www.haskell.org/ghc/  :? for help
Loaded GHCi configuration from /home/ole/.ghci
[1 of 7] Compiling Schemas.Attempt  ( src/Schemas/Attempt.hs, interpreted )
[2 of 7] Compiling Schemas.Untyped  ( src/Schemas/Untyped.hs, interpreted )
[3 of 7] Compiling Schemas.Internal ( src/Schemas/Internal.hs, interpreted )
[4 of 7] Compiling Schemas.Class    ( src/Schemas/Class.hs, interpreted )
[5 of 7] Compiling Schemas.SOP      ( src/Schemas/SOP.hs, interpreted )

src/Schemas/SOP.hs:61:31: error:
    Operator applied to too few arguments: *
    With NoStarIsType, ‘*’ is treated as a regular type operator. 
    Did you mean to use ‘Type’ from Data.Kind instead?
   |
61 |             :: forall (xs :: [*])
   |                               ^
Failed, four modules loaded.
```

Works fine with just `cabal build`.