### PR TITLE
ci: Use newer Haskell setup action

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-haskell@v1.1
+      - uses: haskell/actions/setup@v1.1.5
         with:
           ghc-version: ${{ matrix.ghc }}
 
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-haskell@v1.1
+      - uses: haskell/actions/setup@v1.1.5
 
       - uses: actions/cache@v1
         with:


### PR DESCRIPTION
Upgrade the Haskell action version used to setup the environment. I think this fixes #21.